### PR TITLE
Add an option for the queue name for qsub

### DIFF
--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -18,7 +18,7 @@ function launch(manager::Union(PBSManager, SGEManager), np::Integer, config::Dic
         if manager.queue == ""
             queue = ""
         else
-            queue = "-j " * manager.queue
+            queue = "-q " * manager.queue
         end
 
         jobname = "julia-$(getpid())"


### PR DESCRIPTION
Hi, 

This is a small patch that should allow the specification of a queue name for addprocs_sge(n::Int, queuename::String). 

There is a whole load of commits, but the overall diff is just small.  If I were any better at git rebase's, I would have squashed them all to one.  Sorry about that. 

I can't really test this patch as my version of julia (0.4.0-dev+5301) doesn't load the original CLusterManagers any more.  
julia> addprocs_sge(10)
ERROR: unrecognized keyword argument "manager"
