### PR TITLE
Use files for retrieving the addresses.

### DIFF
--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -34,24 +34,58 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
                 end
             end
         end
+
+        # rm("job*.out")
         np = manager.np
         jobname = "julia-$(getpid())"
-        srun_cmd = `srun -J $jobname -n $np -D $exehome $(srunargs) $exename $exeflags --worker`
+        srun_cmd = `srun -J $jobname -n $np -o "job%3t.out" -D $exehome $(srunargs) $exename $exeflags --worker`
         out, srun_proc = open(srun_cmd)
-        for i = 1:np
-            w = split(split(readline(out), ":")[2], "#")
-            config = WorkerConfig()
-            config.port = int(w[1])
-            config.host = strip(w[2])
-            # Keep a reference to the proc, so it's properly closed once
-            # the last worker exits.
-            config.userdata = srun_proc
-            push!(instances_arr, config)
-            notify(c)
+        local w
+        for i = 0:np - 1
+            print("connecting to worker $(i + 1) out of $np\r")
+            fn = "$exehome/job$(lpad(i, 3, "0")).out"
+            t0 = time()
+            while true
+                if time() > t0 + 60 + np
+                    warn("dropping worker: file not created in $(60 + np) seconds")
+                    break
+                end
+                sleep(0.001)
+                if isfile(fn)
+                    t0 = time()
+                    while true
+                        if time() > t0 + 60 + np
+                            warn("dropping worker: file created, but not written to in $(60 + np) seconds")
+                            break
+                        end
+                        w = open(fn) do f
+                            rf = readline(f)
+                            if ismatch(r"\n", rf)
+                                return split(split(rf, ":")[2], "#")
+                            end
+                            return ""
+                        end
+                        length(w) > 0 && break
+                        sleep(0.001)
+                    end
+                    break
+                end
+            end
+            isfile(fn) && rm(fn)
+            if length(w) > 0
+                config = WorkerConfig()
+                config.port = parse(Int, w[1])
+                config.host = strip(w[2])
+                # Keep a reference to the proc, so it's properly closed once
+                # the last worker exits.
+                config.userdata = srun_proc
+                push!(instances_arr, config)
+                notify(c)
+            end
         end
     catch e
         println("Error launching Slurm job:")
-        println(e)
+        rethrow(e)
     end
 end
 


### PR DESCRIPTION
When launching the slurm workers I redirect the worker information to files instead of `STDOUT`. The reason for this is that, when working with several nodes, the lines got messed up and were difficult to parse. Writing to files might also make it possible to reconnect, but that is another issue.

It is the first time I write code like this so there is probably things that can be improved, but with this, I'm able to launch 512 workers on the cluster.

We probably want to look into options for specifying `-N` and `-c` instead of only `-n` as the user probably would like to have some control over how the workers are distributed across nodes.