### PR TITLE
Utils for identifying hosts and allocation of processes to hosts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,6 @@ describepids() 		# remote pids
 describepids(remotes=1) # local pids
 describepids(remotes=2) # all pids
 
+describepids(pids; filterfn=somefilterfn) #arbitrary selection of pids and filtering of hostnames
+
 </code></pre>

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ An utility is provided to identify processes on the same machine in order to fac
 # retrieve a dictionary, D, where length(keys(D)) represents the number of unqiue hosts
 # keys(D) contains one process on each host 
 # D[pid] is a list of all pids on the same host as pid
-describepids() # processes on remotes
-describepids(remotes=1) #processes on local
-describepids(remotes=2) #all remotes
+describepids() 		# remote pids
+describepids(remotes=1) # local pids
+describepids(remotes=2) # all pids
 
 </code></pre>

--- a/README.md
+++ b/README.md
@@ -65,3 +65,17 @@ of workers pinned to cores in increasing order, For example, worker1 => CPU0, wo
 the workers. Useful when we have multiple CPU sockets, with each socket having multiple cores. A `BALANCED` mode results in workers
 spread across CPU sockets. Default is `BALANCED`
 
+
+
+### Identifying hosts
+
+An utility is provided to identify processes on the same machine in order to facilitate creation of SharedArray objects.
+
+<pre><code>
+# retrieve a dictionary, D, where length(keys(D)) represents the number of unqiue hosts
+# keys(D) contains one process on each host 
+# D[pid] is a list of all pids on the same host as pid
+describepids() # processes on remotes
+describepids(remotes=1) #processes on local
+describepids(remotes=2) #all remotes
+</pre></code>

--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ spread across CPU sockets. Default is `BALANCED`
 An utility is provided to identify processes on the same machine in order to facilitate creation of SharedArray objects.
 
 <pre><code>
+
 # retrieve a dictionary, D, where length(keys(D)) represents the number of unqiue hosts
 # keys(D) contains one process on each host 
 # D[pid] is a list of all pids on the same host as pid
 describepids() # processes on remotes
 describepids(remotes=1) #processes on local
 describepids(remotes=2) #all remotes
-</pre></code>
+
+</code></pre>

--- a/src/ClusterManagers.jl
+++ b/src/ClusterManagers.jl
@@ -9,5 +9,6 @@ include("scyld.jl")
 include("condor.jl")
 include("slurm.jl")
 include("affinity.jl")
+include("utils.jl")
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,73 @@
+
+export describepids 
+
+@doc """
+Make a function that filters out strings matching the hostname of process 1.\n
+""" ->
+function makefiltermaster()
+    master_node = strip(remotecall_fetch(readall, 1, `hostname`), '\n')
+    function filtermaster(x)
+        x != master_node
+    end
+    filtermaster
+end
+
+@doc """
+Return a dictionary topo describing the computing resources Julia currently has access to.\n
+pids should be a list of the pids of interest
+Optional argument filterfn::Function removes processes whose hostname is rejected by the filter.
+length(topo) gives the number of unique nodes.\n
+keys(topo) gives the id of a single process on each compute node.\n
+values(topo) gives the ids of all processes running on each compute node.
+""" ->
+function describepids(pids; filterfn=(x)->true)
+
+    # facts about the machines the processes run on
+    machines = [strip(remotecall_fetch(readall, w, `hostname`), '\n') for w in pids]
+    machine_names = sort!(collect(Set(machines)))
+    machine_names = filter(filterfn, machine_names)
+    num_machines = length(machine_names)
+
+    # nominate a representative process for each machine, and define who it represents
+    representative = zeros(Int64, num_machines)
+    constituency = Dict()
+    for (i,name) in enumerate(machine_names)
+        constituency[i] = Int64[]
+        for (j,machine) in enumerate(machines)
+            if name==machine
+                push!(constituency[i], pids[j])
+                representative[i] = pids[j]
+            end
+        end
+    end
+
+    # assemble the groups of processes keyed by their representatives
+    topo = Dict()
+    for (i,p) in enumerate(representative)
+        topo[p] = constituency[i]
+    end
+
+    topo
+end
+
+
+@doc """
+Return information about the resources (pids) available to us grouped by the machine they are running on.\n
+keyword argument: remote=0 (default) specifies remote machines; remote=1 the local machine; remote=2 all machines.\n 
+length(topo) gives the number of unique nodes.\n
+keys(topo) gives the id of a single process on each compute node.\n
+values(topo) gives the ids of all processes running on each compute node.
+""" ->
+function describepids(; remote=0)
+    pids = procs()
+    if remote==0
+        filterfn = makefiltermaster()
+    elseif remote==1
+        filtertrue = makefiltermaster()
+        filterfn = (x)->!filtertrue(x)
+    elseif remote==2
+        filterfn=(x)->true
+    end
+    describepids(pids; filterfn=filterfn)
+end
+


### PR DESCRIPTION
These functions are intended to help facilitate creation of SharedArrays when using multiple processes on remote nodes. By identifying which pids are running on which hostnames, and returning the information in a handy dict. I work on a SLURM cluster so that's what it has been checked against.
