### PR TITLE
RFC/WIP : added elastic manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,43 @@ to the specified CPU ID.
 of workers pinned to cores in increasing order, For example, worker1 => CPU0, worker2 => CPU1 and so on. `BALANCED` tries to spread
 the workers. Useful when we have multiple CPU sockets, with each socket having multiple cores. A `BALANCED` mode results in workers
 spread across CPU sockets. Default is `BALANCED`
+
+### Using `ElasticManager` (dynamically adding workers to a cluster)
+
+The `ElasticManager` is useful in scenarios where we want to dynamically add workers to a cluster
+It achieves this by listening on a known port on the master. The launched workers connect to this
+port and publish their own host/port information for other workers to connect to.
+
+##### Usage
+
+On the master, you need to instantiate an instance of `ElasticManager`. The constructors defined are:
+```
+ElasticManager(;addr=IPv4("127.0.0.1"), port=9009, cookie=nothing)
+ElasticManager(port) = ElasticManager(;port=port)
+ElasticManager(addr, port) = ElasticManager(;addr=addr, port=port)
+ElasticManager(addr, port, cookie) = ElasticManager(;addr=addr, port=port, cookie=cookie)
+```
+
+On the worker, you need to call `ClusterManagers.elastic_worker` with the addr/port that the master
+is listening on and the same cookie. `elastic_worker` is defined as:
+```
+ClusterManagers.elastic_worker(cookie, addr="127.0.0.1", port=9009; stdout_to_master=true)
+```
+
+For example, on the master:
+
+```
+using ClusterManagers
+em=ElasticManager(cookie="foobar")
+```
+
+and launch each worker locally as
+`echo "using ClusterManagers; ClusterManagers.elastic_worker(\"foobar\")" | julia  &`
+
+or if you want a REPL on the worker, you can start a julia process normally and manually enter
+```
+using ClusterManagers
+@schedule ClusterManagers.elastic_worker("foobar", "addr_of_master", port_of_master; stdout_to_master=false)
+```
+
+The above will yield back the REPL prompt and also display any printed output locally.

--- a/src/ClusterManagers.jl
+++ b/src/ClusterManagers.jl
@@ -16,5 +16,6 @@ include("scyld.jl")
 include("condor.jl")
 include("slurm.jl")
 include("affinity.jl")
+include("elastic.jl")
 
 end

--- a/src/elastic.jl
+++ b/src/elastic.jl
@@ -1,0 +1,133 @@
+# The master process listens on a well-known port
+# Launched workers connect to the master and redirect their STDOUTs to the same
+# Workers can join and leave the cluster on demand.
+
+export ElasticManager, elastic_worker
+
+type ElasticManager <: ClusterManager
+    active::Dict{Int, WorkerConfig}        # active workers
+    pending::Channel{TCPSocket}          # to be added workers
+    terminated::Set{Int}             # terminated worker ids
+
+
+    function ElasticManager(;addr=IPv4("127.0.0.1"), port=9009, cookie=nothing)
+        if VERSION >= v"0.5.0-dev+4047"
+            cookie !== nothing && Base.cluster_cookie(cookie)
+        end
+
+        l_sock = listen(addr, port)
+
+        lman = new(Dict{Int, WorkerConfig}(), Channel{TCPSocket}(typemax(Int)), Set{Int}())
+
+        @schedule begin
+            while true
+                s = accept(l_sock)
+                @schedule process_worker_conn(lman, s)
+            end
+        end
+
+        @schedule process_pending_connections(lman)
+
+        lman
+    end
+end
+
+ElasticManager(port) = ElasticManager(;port=port)
+ElasticManager(addr, port) = ElasticManager(;addr=addr, port=port)
+ElasticManager(addr, port, cookie) = ElasticManager(;addr=addr, port=port, cookie=cookie)
+
+
+function process_worker_conn(mgr::ElasticManager, s::TCPSocket)
+    # Socket is the worker's STDOUT
+    wc = WorkerConfig()
+    wc.io = s
+
+    # Validate cookie
+    if VERSION >= v"0.5.0-dev+4047"
+        cookie = read(s, Base.HDR_COOKIE_LEN)
+        if length(cookie) < Base.HDR_COOKIE_LEN
+            error("Cookie read failed. Connection closed by peer.")
+        end
+
+        self_cookie = Base.cluster_cookie()
+        for i in 1:Base.HDR_COOKIE_LEN
+            if UInt8(self_cookie[i]) != cookie[i]
+                println(i, " ", self_cookie[i], " ", cookie[i])
+                error("Invalid cookie sent by remote worker.")
+            end
+        end
+    end
+
+    put!(mgr.pending, s)
+end
+
+function process_pending_connections(mgr::ElasticManager)
+    while true
+        wait(mgr.pending)
+        try
+            addprocs(mgr)
+        catch e
+            showerror(STDERR, e)
+            Base.show_backtrace(STDERR, Base.catch_backtrace())
+        end
+    end
+end
+
+function launch(mgr::ElasticManager, params::Dict, launched::Array, c::Condition)
+    # The workers have already been started.
+    while isready(mgr.pending)
+        wc=WorkerConfig()
+        wc.io = take!(mgr.pending)
+        push!(launched, wc)
+    end
+
+    notify(c)
+end
+
+function manage(mgr::ElasticManager, id::Integer, config::WorkerConfig, op::Symbol)
+    if op == :register
+        mgr.active[id] = config
+    elseif  op == :deregister
+        delete!(mgr.active, id)
+        push!(mgr.terminated, id)
+    end
+end
+
+function Base.show(io::IO, mgr::ElasticManager)
+    iob = IOBuffer()
+
+    println(iob, "ElasticManager:")
+    print(iob, "  Active workers : [ ")
+    for id in sort(collect(keys(mgr.active)))
+        print(iob, id, ",")
+    end
+    seek(iob, position(iob)-1)
+    println(iob, "]")
+
+    println(iob, "  Number of workers to be added  : ", Base.n_avail(mgr.pending))
+
+    print(iob, "  Terminated workers : [ ")
+    for id in sort(collect(mgr.terminated))
+        print(iob, id, ",")
+    end
+    seek(iob, position(iob)-1)
+    println(iob, "]")
+
+    print(io, takebuf_string(iob))
+end
+
+# Does not return. If executing from a REPL try
+# @schedule connect_to_cluster(.....)
+# addr, port that a ElasticManager on the master processes is listening on.
+function elastic_worker(cookie, addr="127.0.0.1", port=9009; stdout_to_master=true)
+    c = connect(addr, port)
+    if VERSION >= v"0.5.0-dev+4047"
+        write(c, rpad(cookie, Base.HDR_COOKIE_LEN)[1:Base.HDR_COOKIE_LEN])
+    end
+    stdout_to_master && redirect_stdout(c)
+    Base.start_worker(c, cookie)
+end
+
+
+
+


### PR DESCRIPTION
The `ElasticManager` listens on a port on the master. Workers which connect to it are added to the cluster. Details in the updated README.

Please review/comment on the interface and any suggestions at all.
