### PR TITLE
Add keyword arg res_list to addprocs_sge to request cluster specific resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,31 @@ julia>  From worker 2:  compute-6
         From worker 3:  compute-6
 ```
 
+### SGE - an example with resource list
+
+Some clusters require to specify a list of required resources. Required memory has been an [issue for example.](https://github.com/JuliaLang/julia/issues/10390)
+
+```jl
+julia> using ClusterManagers
+
+julia> addprocs_sge(5,res_list="h_vmem=4G,tmem=4G")
+job id is 9827051, waiting for job to start ........
+5-element Array{Int64,1}:
+ 22
+ 23
+ 24
+ 25
+ 26
+
+julia> pmap(x->run(`hostname`),workers());
+
+julia>  From worker 26: lum-7-2.local
+        From worker 23: pace-6-10.local
+        From worker 22: chong-207-10.local
+        From worker 24: pace-6-11.local
+        From worker 25: cheech-207-16.local
+```
+
 ### Using `LocalAffinityManager` (for pinning local workers to specific cores)
 
 - Linux only feature

--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -70,7 +70,7 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
             cmd = `cd $dir && $exename $exeflags $worker_arg`
             qsub_cmd = pipeline(`echo $(Base.shell_escape(cmd))` , (isPBS ?
                     `qsub -N $jobname -j oe -k o -t 1-$np $queue $qsub_env` :
-                    `qsub -N $jobname -terse -j y -t 1-$np $res_list $queue $qsub_env`))
+                    `qsub -N $jobname -terse -j y -R y -t 1-$np $res_list $queue $qsub_env`))
             out,qsub_proc = open(qsub_cmd)
             if !success(qsub_proc)
                 println("batch queue not available (could not run qsub)")

--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -39,6 +39,7 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
             qsub_env = `-v $evar`
         end
 
+
         np = manager.np
 
         jobname = `julia-$(getpid())`
@@ -58,10 +59,18 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
           end
  
         else  # PBS & SGE
+
+            if params[:res_list] == ""
+                res_list = ``
+            else
+                evar = params[:res_list]
+                res_list = `-l $evar`
+            end
+
             cmd = `cd $dir && $exename $exeflags $worker_arg`
             qsub_cmd = pipeline(`echo $(Base.shell_escape(cmd))` , (isPBS ?
                     `qsub -N $jobname -j oe -k o -t 1-$np $queue $qsub_env` :
-                    `qsub -N $jobname -terse -j y -t 1-$np $queue $qsub_env`))
+                    `qsub -N $jobname -terse -j y -t 1-$np $res_list $queue $qsub_env`))
             out,qsub_proc = open(qsub_cmd)
             if !success(qsub_proc)
                 println("batch queue not available (could not run qsub)")
@@ -121,8 +130,8 @@ end
 addprocs_pbs(np::Integer; queue::AbstractString="", qsub_env::AbstractString="") =
         addprocs(PBSManager(np, queue),qsub_env=qsub_env)
 
-addprocs_sge(np::Integer; queue::AbstractString="", qsub_env::AbstractString="") =
-        addprocs(SGEManager(np, queue),qsub_env=qsub_env)
+addprocs_sge(np::Integer; queue::AbstractString="", qsub_env::AbstractString="", res_list::AbstractString="") =
+        addprocs(SGEManager(np, queue),qsub_env=qsub_env,res_list=res_list)
 
 addprocs_qrsh(np::Integer; queue::AbstractString="", qsub_env::AbstractString="") =
         addprocs(QRSHManager(np, queue),qsub_env=qsub_env)

--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -70,7 +70,7 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
             cmd = `cd $dir && $exename $exeflags $worker_arg`
             qsub_cmd = pipeline(`echo $(Base.shell_escape(cmd))` , (isPBS ?
                     `qsub -N $jobname -j oe -k o -t 1-$np $queue $qsub_env` :
-                    `qsub -N $jobname -terse -j y -R y -t 1-$np $res_list $queue $qsub_env`))
+                    `qsub -N $jobname -terse -j y -R y -t 1-$np -V $res_list $queue $qsub_env`))
             out,qsub_proc = open(qsub_cmd)
             if !success(qsub_proc)
                 println("batch queue not available (could not run qsub)")


### PR DESCRIPTION
adds a keyword `res_list` to `addprocs_sge`. This addresses an issue with SGE clusters who require an explicit resource list to be passed (like runtime, memory required etc). This could not be passed via `qsub_env` because we paste the flag `-v` in front of it. the resource list uses flag `-l`.