### PR TITLE
Fixed bug trying to close nullable port

### DIFF
--- a/src/condor.jl
+++ b/src/condor.jl
@@ -75,7 +75,7 @@ end
 function manage(manager::HTCManager, id::Integer, config::WorkerConfig, op::Symbol)
     if op == :finalize
         if !isnull(config.io)
-            close(config.io)
+            close(get(config.io))
         end
 #     elseif op == :interrupt
 #         job = config[:job]


### PR DESCRIPTION
The original `close()` tries to close a `Nullable` object, without the `get()`