### PR TITLE
Implemented job id tracking and job removal

### DIFF
--- a/src/condor.jl
+++ b/src/condor.jl
@@ -19,12 +19,11 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
     scriptf = open("$tdir/$jobname.sh", "w")
     println(scriptf, "#!/bin/sh")
     println(scriptf, "cd $(Base.shell_escape(dir))")
-    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg)) | /usr/bin/telnet $(Base.shell_escape(hostname)) $portnum")
+    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg)) \$1 | /usr/bin/telnet $(Base.shell_escape(hostname)) $portnum")
     close(scriptf)
 
     subf = open("$tdir/$jobname.sub", "w")
     println(subf, "executable = /bin/bash")
-    println(subf, "arguments = ./$jobname.sh")
     println(subf, "universe = vanilla")
     println(subf, "should_transfer_files = yes")
     println(subf, "transfer_input_files = $tdir/$jobname.sh")
@@ -32,6 +31,7 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
     for i = 1:np
         println(subf, "output = $tdir/$jobname-$i.o")
         println(subf, "error= $tdir/$jobname-$i.e")
+        println(subf, "arguments = ./$jobname.sh $(i-1)")
         println(subf, "queue")
     end
     close(subf)
@@ -44,6 +44,7 @@ function launch(manager::HTCManager, params::Dict, instances_arr::Array, c::Cond
         portnum = rand(8000:9000)
         server = listen(portnum)
         np = manager.np
+        jobdata = Dict()
 
         script = condor_script(portnum, np, params)
         out,proc = open(`condor_submit $script`)
@@ -51,7 +52,13 @@ function launch(manager::HTCManager, params::Dict, instances_arr::Array, c::Cond
             println("batch queue not available (could not run condor_submit)")
             return
         end
-        print(readline(out))
+        outstring = readstring(out)
+        println(split(outstring,"\n")[1])
+        m = match(r"submitted to cluster (\d+)\.",outstring)
+        if m != nothing
+            jobdata[:id] = parse(m[1])
+        end
+
         print("Waiting for $np workers: ")
 
         for i=1:np
@@ -59,6 +66,7 @@ function launch(manager::HTCManager, params::Dict, instances_arr::Array, c::Cond
             config = WorkerConfig()
 
             config.io = conn
+            config.userdata = copy(jobdata)
 
             push!(instances_arr, config)
             notify(c)
@@ -72,18 +80,30 @@ function launch(manager::HTCManager, params::Dict, instances_arr::Array, c::Cond
    end
 end
 
+function kill(manager::HTCManager, pid::Int64, config::WorkerConfig)
+    if !isnull(config.userdata)
+        jobdata = get(config.userdata)
+        job_id = "$(jobdata[:id]).$(jobdata[:proc])"
+        if !success(`condor_rm $job_id`)
+            println("Error removing condor job $job_id")
+        end
+    end
+end
+
 function manage(manager::HTCManager, id::Integer, config::WorkerConfig, op::Symbol)
     if op == :finalize
         if !isnull(config.io)
             close(get(config.io))
         end
-#     elseif op == :interrupt
-#         job = config[:job]
-#         task = config[:task]
-#         # this does not currently work
-#         if !success(`qsig -s 2 -t $task $job`)
-#             println("Error sending a Ctrl-C to julia worker $id (job: $job, task: $task)")
-#         end
+    elseif op == :register
+        if !isnull(config.userdata)
+            remoteargs = remotecall_fetch(getfield,id,Base,:ARGS)
+            if length(remoteargs)==1
+                get(config.userdata)[:proc] = parse(remoteargs[1])
+            end
+        end
+    elseif op == :interrupt
+        kill(manager,id,config)
     end
 end
 

--- a/src/condor.jl
+++ b/src/condor.jl
@@ -75,7 +75,7 @@ end
 function manage(manager::HTCManager, id::Integer, config::WorkerConfig, op::Symbol)
     if op == :finalize
         if !isnull(config.io)
-            close(config.io)
+            close(get(config.io))
         end
 #     elseif op == :interrupt
 #         job = config[:job]


### PR DESCRIPTION
Made a bunch of changes to get the current job id, and process id to be able to refer to individual worker condor processes individually. The job id is taken from the original command output, and the individual worker ids are obtained by passing them as arguments to the command and then reading them back when the workers load.

I tried to flesh out the other cluster methods appropriately. I haven't worked with Julia's cluster interface before, but it all appears correct-ish (or, at least it works on my cluster)