### PR TITLE
Allow more flexible queue parameters [fixes #68]

### DIFF
--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -28,7 +28,14 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
             queue = ``
         else
             this_queue = manager.queue
-            queue = `-q $this_queue`
+            # If a different queue switch is used (eg -P) or user wants to pass in
+            # multiple arguments, then treat each word as a separate arguments:
+            words = split(this_queue)
+            if startswith(this_queue, "-")
+                queue = `$words`
+            else
+                 queue = `-q $words`
+            end
         end
 
 


### PR DESCRIPTION
For those who use SGE but don't use "-q" to define the queue name this allows them to define their own switch and also allows users to insert extra launch arguments if desired.