### PR TITLE
Added res_list to addprocs_qrsh

### DIFF
--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -40,13 +40,21 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
         end
 
 
+        if params[:res_list] == ""
+            res_list = ``
+        else
+            evar = params[:res_list]
+            res_list = `-l $evar`
+        end
+
+
         np = manager.np
 
         jobname = `julia-$(getpid())`
 
         if isa(manager, QRSHManager)
           cmd = `cd $dir '&&' $exename $exeflags $worker_arg`
-          qrsh_cmd = `qrsh $queue $qsub_env -V -N $jobname -now n "$cmd"`
+          qrsh_cmd = `qrsh $queue $qsub_env $res_list -V -N $jobname -now n "$cmd"`
 
           stream_proc = [open(qrsh_cmd) for i in 1:np]
 
@@ -59,13 +67,6 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
           end
  
         else  # PBS & SGE
-
-            if params[:res_list] == ""
-                res_list = ``
-            else
-                evar = params[:res_list]
-                res_list = `-l $evar`
-            end
 
             cmd = `cd $dir '&&' $exename $exeflags $worker_arg`
             qsub_cmd = pipeline(`echo $(Base.shell_escape(cmd))` , (isPBS ?
@@ -133,5 +134,5 @@ addprocs_pbs(np::Integer; queue::AbstractString="", qsub_env::AbstractString="",
 addprocs_sge(np::Integer; queue::AbstractString="", qsub_env::AbstractString="", res_list::AbstractString="") =
         addprocs(SGEManager(np, queue),qsub_env=qsub_env,res_list=res_list)
 
-addprocs_qrsh(np::Integer; queue::AbstractString="", qsub_env::AbstractString="") =
-        addprocs(QRSHManager(np, queue),qsub_env=qsub_env)
+addprocs_qrsh(np::Integer; queue::AbstractString="", qsub_env::AbstractString="", res_list::AbstractString="") =
+        addprocs(QRSHManager(np, queue),qsub_env=qsub_env,res_list=res_list)


### PR DESCRIPTION
Add support for resource list in `addprocs_qrsh` following the same style of `addprocs_sge` and `addprocs_pbs`. Tested with `h_rt` and `h_vmem` resources on an SGE cluster (OGS/GE 2011.11p1).