### PR TITLE
make Julia 0.7 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: julia
+os:
+  - osx
+  - linux
+julia:
+  - 0.7
+  - 1.0
+  - nightly
+notifications:
+  email: false
+#script: # the default script is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Example"); Pkg.test("Example"; coverage=true)';
+#after_success:
+#  - julia -e 'cd(Pkg.dir("Clustermanagers")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+#  - julia -e 'cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5
-Compat 0.7.8
+julia 0.7

--- a/src/ClusterManagers.jl
+++ b/src/ClusterManagers.jl
@@ -1,18 +1,12 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
-
 module ClusterManagers
 
-using Compat
+using Distributed
+using Sockets
 
 export launch, manage, kill, init_worker, connect
-import Base: launch, manage, kill, init_worker, connect
+import Distributed: launch, manage, kill, init_worker, connect
 
-worker_arg = `--worker`
-
-function __init__()
-    global worker_arg
-    worker_arg = `--worker=$(Base.cluster_cookie())`
-end
+worker_arg() = `--worker=$(cluster_cookie())`
 
 # PBS doesn't have the same semantics as SGE wrt to file accumulate,
 # a different solution will have to be found

--- a/src/affinity.jl
+++ b/src/affinity.jl
@@ -16,7 +16,7 @@ mutable struct LocalAffinityManager <: ClusterManager
             else
                 # mode == BALANCED
                 if np > 1
-                    affinities = [Int(floor(i)) for i in linspace(0, CPU_CORES - 1e-3, np)]
+                    affinities = [Int(floor(i)) for i in range(0, stop=CPU_CORES - 1e-3, length=np)]
                 else
                     affinities = [0]
                 end

--- a/src/affinity.jl
+++ b/src/affinity.jl
@@ -4,7 +4,7 @@ export LocalAffinityManager, AffinityMode, COMPACT, BALANCED
 
 @enum AffinityMode COMPACT BALANCED
 
-type LocalAffinityManager <: ClusterManager
+mutable struct LocalAffinityManager <: ClusterManager
     affinities::Array{Int}
 
     function LocalAffinityManager(;np=CPU_CORES, mode::AffinityMode=BALANCED, affinities::Array{Int}=[])
@@ -35,7 +35,7 @@ function launch(manager::LocalAffinityManager, params::Dict, launched::Array, c:
 
     for core_id in manager.affinities
         io, pobj = open(detach(
-            setenv(`taskset -c $core_id $(Base.julia_cmd(exename)) $exeflags $worker_arg`, dir=dir)), "r")
+            setenv(`taskset -c $core_id $(Base.julia_cmd(exename)) $exeflags $(worker_arg())`, dir=dir)), "r")
         wconfig = WorkerConfig()
         wconfig.process = pobj
         wconfig.io = io

--- a/src/condor.jl
+++ b/src/condor.jl
@@ -2,7 +2,7 @@
 
 export HTCManager, addprocs_htc
 
-immutable HTCManager <: ClusterManager
+struct HTCManager <: ClusterManager
     np::Integer
 end
 
@@ -19,7 +19,7 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
     scriptf = open("$tdir/$jobname.sh", "w")
     println(scriptf, "#!/bin/sh")
     println(scriptf, "cd $(Base.shell_escape(dir))")
-    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg)) | /usr/bin/telnet $(Base.shell_escape(hostname)) $portnum")
+    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg())) | /usr/bin/telnet $(Base.shell_escape(hostname)) $portnum")
     close(scriptf)
 
     subf = open("$tdir/$jobname.sub", "w")

--- a/src/elastic.jl
+++ b/src/elastic.jl
@@ -64,8 +64,8 @@ function process_pending_connections(mgr::ElasticManager)
         try
             addprocs(mgr; topology=mgr.topology)
         catch e
-            showerror(STDERR, e)
-            Base.show_backtrace(STDERR, Base.catch_backtrace())
+            showerror(stderr, e)
+            Base.show_backtrace(stderr, Base.catch_backtrace())
         end
     end
 end

--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -1,16 +1,16 @@
 export PBSManager, SGEManager, QRSHManager, addprocs_pbs, addprocs_sge, addprocs_qrsh
 
-immutable PBSManager <: ClusterManager
+struct PBSManager <: ClusterManager
     np::Integer
     queue::AbstractString
 end
 
-immutable SGEManager <: ClusterManager
+struct SGEManager <: ClusterManager
     np::Integer
     queue::AbstractString
 end
 
-immutable QRSHManager <: ClusterManager
+struct QRSHManager <: ClusterManager
     np::Integer
     queue::AbstractString
 end
@@ -45,7 +45,7 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
         jobname = `julia-$(getpid())`
 
         if isa(manager, QRSHManager)
-          cmd = `cd $dir '&&' $exename $exeflags $worker_arg`
+          cmd = `cd $dir '&&' $exename $exeflags $(worker_arg())`
           qrsh_cmd = `qrsh $queue $qsub_env -V -N $jobname -now n "$cmd"`
 
           stream_proc = [open(qrsh_cmd) for i in 1:np]
@@ -67,7 +67,7 @@ function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
                 res_list = `-l $evar`
             end
 
-            cmd = `cd $dir '&&' $exename $exeflags $worker_arg`
+            cmd = `cd $dir '&&' $exename $exeflags $(worker_arg())`
             qsub_cmd = pipeline(`echo $(Base.shell_escape(cmd))` , (isPBS ?
                     `qsub -N $jobname -j oe -k o -t 1-$np $queue $qsub_env $res_list` :
                     `qsub -N $jobname -terse -j y -R y -t 1-$np -V $res_list $queue $qsub_env`))

--- a/src/scyld.jl
+++ b/src/scyld.jl
@@ -1,6 +1,6 @@
 export addprocs_scyld, ScyldManager
 
-immutable ScyldManager <: ClusterManager
+struct ScyldManager <: ClusterManager
     np::Integer
 end
 
@@ -19,7 +19,7 @@ function launch(manager::ScyldManager, params::Dict, instances_arr::Array, c::Co
         end
         nodes = split(chomp(readline(out)),':')
         for (i,node) in enumerate(nodes)
-            cmd = `cd $dir '&&' $exename $exeflags $worker_arg`
+            cmd = `cd $dir '&&' $exename $exeflags $(worker_arg())`
             cmd = detach(`bpsh $node sh -l -c $(Base.shell_escape(cmd))`)
             config = WorkerConfig()
 

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -36,7 +36,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         end
 
         # cleanup old files
-        map(rm, filter(t -> ismatch(r"job.*\.out", t), readdir(exehome)))
+        map(rm, filter(t -> occursin(r"job.*\.out", t), readdir(exehome)))
 
         np = manager.np
         jobname = "julia-$(getpid())"

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -2,7 +2,7 @@
 
 export SlurmManager, addprocs_slurm
 
-immutable SlurmManager <: ClusterManager
+struct SlurmManager <: ClusterManager
     np::Integer
 end
 
@@ -40,7 +40,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
 
         np = manager.np
         jobname = "julia-$(getpid())"
-        srun_cmd = `srun -J $jobname -n $np -o "job%4t.out" -D $exehome $(srunargs) $exename $exeflags $worker_arg`
+        srun_cmd = `srun -J $jobname -n $np -o "job%4t.out" -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
         out, srun_proc = open(srun_cmd)
         for i = 0:np - 1
             print("connecting to worker $(i + 1) out of $np\r")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,2 @@
+# only package loading for now
+using ClusterManagers


### PR DESCRIPTION
- updated for Julia 0.7+
- dropped support for older Julia versions
- enabled basic CI on travis
- updated ElasticManager for 0.7 changes