### PR TITLE
minor 0.7+ fixes and updates to slurm.jl

### DIFF
--- a/src/ClusterManagers.jl
+++ b/src/ClusterManagers.jl
@@ -6,7 +6,8 @@ using Sockets
 export launch, manage, kill, init_worker, connect
 import Distributed: launch, manage, kill, init_worker, connect
 
-worker_arg() = `--worker=$(cluster_cookie())`
+worker_arg() = `--worker=$(Distributed.init_multi(); cluster_cookie())`
+
 
 # PBS doesn't have the same semantics as SGE wrt to file accumulate,
 # a different solution will have to be found

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -13,8 +13,8 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         exename = params[:exename]
         exeflags = params[:exeflags]
 
-        stdkeys = keys(Base.Distributed.default_addprocs_params())
-        p = filter((x,y) -> !(x in stdkeys), params)
+        stdkeys = keys(Distributed.default_addprocs_params())
+        p = filter(x->!(x[1] in stdkeys), params)
 
         srunargs = []
         for k in keys(p)
@@ -41,7 +41,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         np = manager.np
         jobname = "julia-$(getpid())"
         srun_cmd = `srun -J $jobname -n $np -o "job%4t.out" -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
-        out, srun_proc = open(srun_cmd)
+        srun_proc = open(srun_cmd)
         for i = 0:np - 1
             print("connecting to worker $(i + 1) out of $np\r")
             local w=[]


### PR DESCRIPTION
Fixes SLURM functionalities by updating some deprecated syntax in slurm.jl, and replacing cluster_cookie() call. Also adresses a filter() deprecation warning