### PR TITLE
race condition for multiple in-bound connections

### DIFF
--- a/src/elastic.jl
+++ b/src/elastic.jl
@@ -22,8 +22,9 @@ struct ElasticManager <: ClusterManager
 
         @async begin
             while true
-                s = accept(l_sock)
-                @async process_worker_conn(lman, s)
+                let s = accept(l_sock)
+                    @async process_worker_conn(lman, s)
+                end
             end
         end
 


### PR DESCRIPTION
When multiple connections are pending at the same time, the `s` variable gets overwritten before the previous accepted socket can be passed to `process_worker_conn`.