### PR TITLE
Change the naming pattern of .out files to avoid conflicts

### DIFF
--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -57,12 +57,13 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
 
         np = manager.np
         jobname = "julia-$(getpid())"
-        srun_cmd = `srun -J $jobname -n $np -o "$(joinpath(job_file_loc, "job%4t.out"))" -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
+		jobID = String(ENV["SLURM_JOB_ID"])
+        srun_cmd = `srun -J $jobname -n $np -o "$(joinpath(job_file_loc, "job-$jobID-%4t.out"))" -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
         srun_proc = open(srun_cmd)
         for i = 0:np - 1
             print("connecting to worker $(i + 1) out of $np\r")
             local w=[]
-            fn = "$(joinpath(exehome, job_file_loc))/job$(lpad(i, 4, "0")).out"
+            fn = "$(joinpath(exehome, job_file_loc))/job-$jobID-$(lpad(i, 4, "0")).out"
             t0 = time()
             while true
                 if time() > t0 + 60 + np

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -57,13 +57,13 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
 
         np = manager.np
         jobname = "julia-$(getpid())"
-		jobID = String(ENV["SLURM_JOB_ID"])
-        srun_cmd = `srun -J $jobname -n $np -o "$(joinpath(job_file_loc, "job-$jobID-%4t.out"))" -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
+	jobID = String(ENV["SLURM_JOB_ID"])
+        srun_cmd = `srun -J $jobname -n $np -o "$(joinpath(job_file_loc, jobID,"job%4t.out"))" -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
         srun_proc = open(srun_cmd)
         for i = 0:np - 1
             print("connecting to worker $(i + 1) out of $np\r")
             local w=[]
-            fn = "$(joinpath(exehome, job_file_loc))/job-$jobID-$(lpad(i, 4, "0")).out"
+            fn = "$(joinpath(exehome, job_file_loc, jobID))/job$(lpad(i, 4, "0")).out"
             t0 = time()
             while true
                 if time() > t0 + 60 + np


### PR DESCRIPTION
I added the environmental variable ENV["SLURM_JOB_ID"] in the naming pattern of the job.out files so that jobs that start simultaneously in the same folder to do not attempt to write on the same files causing errors in the cluster.