### PR TITLE
Overwrite "connecting to worker" messages on Slurm

### DIFF
--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -61,12 +61,13 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         srun_cmd = `srun -J $jobname -n $np -o "$(joinpath(job_file_loc, "job-$jobID-%4t.out"))" -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
         srun_proc = open(srun_cmd)
         for i = 0:np - 1
-            println("connecting to worker $(i + 1) out of $np")
+            print("connecting to worker $(i + 1) out of $np\r")
             local w=[]
             fn = "$(joinpath(exehome, job_file_loc))/job-$jobID-$(lpad(i, 4, "0")).out"
             t0 = time()
             while true
                 if time() > t0 + 60 + np
+                    println()
                     @warn "dropping worker: file not created in $(60 + np) seconds"
                     break
                 end

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -61,13 +61,16 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         srun_cmd = `srun -J $jobname -n $np -o "$(joinpath(job_file_loc, "job-$jobID-%4t.out"))" -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
         srun_proc = open(srun_cmd)
         for i = 0:np - 1
-            print("connecting to worker $(i + 1) out of $np\r")
+            print("connecting to worker $(i + 1) out of $np",
+                ifelse(i == np - 1,"\n","\r"))
             local w=[]
             fn = "$(joinpath(exehome, job_file_loc))/job-$jobID-$(lpad(i, 4, "0")).out"
             t0 = time()
             while true
                 if time() > t0 + 60 + np
-                    println()
+                    if i != np - 1
+                        println()
+                    end
                     @warn "dropping worker: file not created in $(60 + np) seconds"
                     break
                 end


### PR DESCRIPTION
Currently addprocs_slurm prints messages as it connects to new workers, and every new message is printed on a new line. For 100+ workers this might leave the REPL full of "connecting to worker" messages, and make it difficult to view previous commands and results. This PR changes this such that the messages are overwritten, so you effectively get a counter that tracks how many workers have been connected to.

Before this PR:

```julia
julia> addprocs_slurm(28);
[:lazy, :topology, :exeflags, :enable_threaded_blas, :exename, :dir]
Dict{Symbol,Any}()
removing old files
removing old Setting up srun commands
connecting to worker 1 out of 28
connecting to worker 2 out of 28
connecting to worker 3 out of 28
connecting to worker 4 out of 28
connecting to worker 5 out of 28
connecting to worker 6 out of 28
connecting to worker 7 out of 28
connecting to worker 8 out of 28
connecting to worker 9 out of 28
connecting to worker 10 out of 28
connecting to worker 11 out of 28
connecting to worker 12 out of 28
connecting to worker 13 out of 28
connecting to worker 14 out of 28
connecting to worker 15 out of 28
connecting to worker 16 out of 28
connecting to worker 17 out of 28
connecting to worker 18 out of 28
connecting to worker 19 out of 28
connecting to worker 20 out of 28
connecting to worker 21 out of 28
connecting to worker 22 out of 28
connecting to worker 23 out of 28
connecting to worker 24 out of 28
connecting to worker 25 out of 28
connecting to worker 26 out of 28
connecting to worker 27 out of 28
connecting to worker 28 out of 28
```

After this PR:

```julia
julia> addprocs_slurm(28);
[:lazy, :topology, :exeflags, :enable_threaded_blas, :exename, :dir]
Dict{Symbol,Any}()
removing old files
removing old Setting up srun commands
connecting to worker 28 out of 28
```

Warnings on being unable to connect still get printed on the next line, and introduce a line break.