### PR TITLE
Slurm robust to no jobid and to node warnings

### DIFF
--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -66,7 +66,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         for i = 0:np - 1
             println("connecting to worker $(i + 1) out of $np")
             local slurm_spec_match = nothing
-            fn = "$(joinpath(exehome, job_file_loc))/job-$jobID-$(lpad(i, 4, "0")).out"
+            fn = make_job_output_path(lpad(i, 4, "0"))
             t0 = time()
             while true
                 slurm_spec_match = open(fn) do f

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -17,11 +17,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
 
         stdkeys = keys(Distributed.default_addprocs_params())
 
-	println(stdkeys)
         p = filter(x->(!(x[1] in stdkeys) && x[1] != :job_file_loc), params)
-	println(p)
-
-
 
         srunargs = []
         for k in keys(p)
@@ -49,10 +45,6 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         if !isdir(job_file_loc)
             mkdir(job_file_loc)
         end
-
-        # println("removing old files")
-        # cleanup old files
-	    # map(f->rm(joinpath(job_file_loc, f)), filter(t -> occursin(r"job(.*?).out", t), readdir(job_file_loc)))
 
         np = manager.np
         jobname = "julia-$(getpid())"

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -69,16 +69,18 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
             fn = make_job_output_path(lpad(i, 4, "0"))
             t0 = time()
             while true
-                slurm_spec_match = open(fn) do f
-                    for line in eachline(f)
-                        re_match = match(slurm_spec_regex, line)
-                        if re_match !== nothing
-                            return re_match
+                if isfile(fn) && filesize(fn) > 0
+                    slurm_spec_match = open(fn) do f
+                        for line in eachline(f)
+                            re_match = match(slurm_spec_regex, line)
+                            if re_match !== nothing
+                                return re_match
+                            end
                         end
                     end
-                end
-                if slurm_spec_match !== nothing
-                    break
+                    if slurm_spec_match !== nothing
+                        break
+                    end
                 end
             end
             config = WorkerConfig()

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -56,7 +56,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         slurm_spec_regex = r"([\w]+):([\d]+)#(\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})"
         for i = 0:np - 1
             println("connecting to worker $(i + 1) out of $np")
-            local slurm_spec_match = nothing
+            slurm_spec_match = nothing
             fn = make_job_output_path(lpad(i, 4, "0"))
             t0 = time()
             while true

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -60,17 +60,20 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
             fn = make_job_output_path(lpad(i, 4, "0"))
             t0 = time()
             while true
+                # Wait for output log to be created and populated, then parse
                 if isfile(fn) && filesize(fn) > 0
                     slurm_spec_match = open(fn) do f
+                        # Due to error and warning messages, the specification
+                        # may not appear on the file's first line
                         for line in eachline(f)
                             re_match = match(slurm_spec_regex, line)
                             if re_match !== nothing
-                                return re_match
+                                return re_match    # only returns from do-block
                             end
                         end
                     end
                     if slurm_spec_match !== nothing
-                        break
+                        break   # break if specification found
                     end
                 end
             end

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -50,10 +50,9 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
             mkdir(job_file_loc)
         end
 
-        println("removing old files")
+        # println("removing old files")
         # cleanup old files
-	map(f->rm(joinpath(job_file_loc, f)), filter(t -> occursin(r"job(.*?).out", t), readdir(job_file_loc)))
-        println("removing old Setting up srun commands")
+	    # map(f->rm(joinpath(job_file_loc, f)), filter(t -> occursin(r"job(.*?).out", t), readdir(job_file_loc)))
 
         np = manager.np
         jobname = "julia-$(getpid())"


### PR DESCRIPTION
Resolves #127 

Resolves additional bug where the port and IP info are not parsed when a warning or error from the node (e.g. "TMPDIR could not be created") occupies the first lines of the output file.

Related but unnecessary changes:  I removed "job_" from the output file name.  I stopped the automatic deletion of previous logs.  At the very least, that should have a flag associated with it.