### PR TITLE
Add the `ExistingProcessManager` cluster manager

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClusterManagers"
 uuid = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/ClusterManagers.jl
+++ b/src/ClusterManagers.jl
@@ -19,5 +19,6 @@ include("slurm.jl")
 include("affinity.jl")
 include("elastic.jl")
 include("lsf.jl")
+include("existing.jl")
 
 end

--- a/src/existing.jl
+++ b/src/existing.jl
@@ -1,0 +1,43 @@
+import Distributed
+
+export ExistingProcessManager, addprocs_existing
+
+struct ExistingProcessManager <: Distributed.ClusterManager
+    wconfigs::Vector{Distributed.WorkerConfig}
+end
+
+function ExistingProcessManager(hosts_and_ports::Vector{Tuple{String, Int}})
+    num_workers = length(hosts_and_ports)
+    wconfigs = Vector{Distributed.WorkerConfig}(undef, num_workers)
+    for i = 1:num_workers
+        host_and_port = hosts_and_ports[i]
+        host = host_and_port[1]
+        port = host_and_port[2]
+        wconfig = Distributed.WorkerConfig()
+        wconfig.host = host
+        wconfig.port = port
+        wconfigs[i] = wconfig
+    end
+    return ExistingProcessManager(wconfigs)
+end
+
+function Distributed.launch(manager::ExistingProcessManager,
+                            params::Dict,
+                            launched::Array,
+                            launch_ntfy::Condition)
+    while !isempty(manager.wconfigs)
+        wconfig = pop!(manager.wconfigs)
+        push!(launched, wconfig)
+        notify(launch_ntfy)
+    end
+    return nothing
+end
+
+function Distributed.manage(manager::ExistingProcessManager,
+                            id::Integer,
+                            config::Distributed.WorkerConfig,
+                            op::Symbol)
+    return nothing
+end
+
+addprocs_existing(workers; kwargs...) = Distributed.addprocs(ExistingProcessManager(workers); kwargs...)


### PR DESCRIPTION
Closes #147 

## Summary 

This pull request adds the `ExistingProcessManager` cluster manager. Because this is a non-breaking feature, I have bumped the version number from 0.4.0 to 0.4.1.

This is a resubmission of #147.

## Example usage

First, run the following command four times. It can be on the same machine or on different machines.
```bash
julia --worker=1234567890abcdef &
```

Make note of the hosts and port numbers that are printed to stdout. For this example, we will suppose that the hosts and port numbers that were printed to stdout were as follows:
| Host               | Port  |
| ------------- | ----- |
| 192.168.1.151 | 9684 |
| 192.168.1.151 | 9685 |
| 192.168.1.151 | 9686 |
| 192.168.1.151 | 9687 |

Now, open a Julia session and run the following: (in the `workers` array, replace the hosts and port numbers with the hosts and port numbers that you received in the previous step)
```julia
julia> import ClusterManagers, Distributed

julia> Distributed.cluster_cookie("1234567890abcdef")

julia> workers = [
       ("192.168.1.151", 9684),
       ("192.168.1.151", 9685),
       ("192.168.1.151", 9686),
       ("192.168.1.151", 9687),
       ]

julia> Distributed.addprocs(ClusterManagers.ExistingProcessManager(workers))
```

## Motivation

The idea here is that for whatever reason, you have already manually started the Julia worker processes by doing `julia --worker=my_cluster_cookie`. Those workers are now running, and you want to add them as processes so that Distributed is aware of them. This is what the `ExistingProcessManager` cluster manager allows you to do.

## Constructors

There are two ways to construct a `ExistingProcessManager`:
1. Pass a vector of tuples, where the first element of each tuple is the host, and the second element of each tuple is the port number.
2. Pass a vector of `Distributed.WorkerConfig`s.