### PR TITLE
Fix up and add flexibility to HTCManager

### DIFF
--- a/src/condor.jl
+++ b/src/condor.jl
@@ -10,6 +10,10 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
     dir = params[:dir]
     exename = params[:exename]
     exeflags = params[:exeflags]
+    extrajdl = get(params, :extrajdl, [])
+    extraenv = get(params, :extraenv, [])
+    extrainputs = get(params, :extrainputs, [])
+    telnetloc = get(params, :telnetloc, "/usr/bin/telnet")
     home = ENV["HOME"]
     hostname = ENV["HOSTNAME"]
     jobname = "julia-$(getpid())"
@@ -19,16 +23,24 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
     scriptf = open("$tdir/$jobname.sh", "w")
     println(scriptf, "#!/bin/sh")
     println(scriptf, "cd $(Base.shell_escape(dir))")
-    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg())) | /usr/bin/telnet $(Base.shell_escape(hostname)) $portnum")
+    for line in extraenv
+        println(scriptf, line)
+    end
+    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg())) | $telnetloc $(Base.shell_escape(hostname)) $portnum")
     close(scriptf)
 
+    input_files = ["$tdir/$jobname.sh"]
+    push!(input_files, extrainputs...)
     subf = open("$tdir/$jobname.sub", "w")
     println(subf, "executable = /bin/bash")
     println(subf, "arguments = ./$jobname.sh")
     println(subf, "universe = vanilla")
     println(subf, "should_transfer_files = yes")
-    println(subf, "transfer_input_files = $tdir/$jobname.sh")
+    println(subf, "transfer_input_files = $(join(input_files, ','))")
     println(subf, "Notification = Error")
+    for line in extrajdl
+        println(subf, line)
+    end
     for i = 1:np
         println(subf, "output = $tdir/$jobname-$i.o")
         println(subf, "error= $tdir/$jobname-$i.e")
@@ -42,16 +54,15 @@ end
 function launch(manager::HTCManager, params::Dict, instances_arr::Array, c::Condition)
     try
         portnum = rand(8000:9000)
-        server = listen(portnum)
+        _, server = listenany(Sockets.getaddrinfo("0.0.0.0"), portnum)
         np = manager.np
 
         script = condor_script(portnum, np, params)
-        out,proc = open(`condor_submit $script`)
-        if !success(proc)
+        cmd = `condor_submit $script`
+        if !success(cmd)
             println("batch queue not available (could not run condor_submit)")
             return
         end
-        print(readline(out))
         print("Waiting for $np workers: ")
 
         for i=1:np

--- a/src/condor.jl
+++ b/src/condor.jl
@@ -22,10 +22,10 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
 
     scriptf = open("$tdir/$jobname.sh", "w")
     println(scriptf, "#!/bin/sh")
-    println(scriptf, "cd $(Base.shell_escape(dir))")
     for line in extraenv
         println(scriptf, line)
     end
+    println(scriptf, "cd $(Base.shell_escape(dir))")
     println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg())) | $telnetloc $(Base.shell_escape(hostname)) $portnum")
     close(scriptf)
 

--- a/src/condor.jl
+++ b/src/condor.jl
@@ -26,7 +26,7 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
         println(scriptf, line)
     end
     println(scriptf, "cd $(Base.shell_escape(dir))")
-    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg())) | $telnetexe $(Base.shell_escape(hostname)) $portnum")
+    println(scriptf, "$(Base.shell_escape(exename)) $exeflags $(Base.shell_escape(worker_arg())) | $telnetexe $(Base.shell_escape(hostname)) $portnum")
     close(scriptf)
 
     input_files = ["$tdir/$jobname.sh"]

--- a/src/condor.jl
+++ b/src/condor.jl
@@ -13,7 +13,7 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
     extrajdl = get(params, :extrajdl, [])
     extraenv = get(params, :extraenv, [])
     extrainputs = get(params, :extrainputs, [])
-    telnetloc = get(params, :telnetloc, "/usr/bin/telnet")
+    telnetexe = get(params, :telnetexe, "/usr/bin/telnet")
     home = ENV["HOME"]
     hostname = ENV["HOSTNAME"]
     jobname = "julia-$(getpid())"
@@ -26,7 +26,7 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
         println(scriptf, line)
     end
     println(scriptf, "cd $(Base.shell_escape(dir))")
-    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg())) | $telnetloc $(Base.shell_escape(hostname)) $portnum")
+    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(worker_arg())) | $telnetexe $(Base.shell_escape(hostname)) $portnum")
     close(scriptf)
 
     input_files = ["$tdir/$jobname.sh"]


### PR DESCRIPTION
Currently, HTCManager is pretty rigid in terms of the job submission script and worker node script, and doesn't communicate properly as noted in https://github.com/JuliaParallel/ClusterManagers.jl/issues/150 and https://github.com/JuliaParallel/ClusterManagers.jl/issues/107. 

To address the first, I added parameters that let one send extra inputs to the worker node, insert lines/ClassAds in the job submission script, add extra commands before julia is invoked on the worker node, and modify the location/command used in place of `telnet`. So one can do something like
```julia
myparams = Dict(
                :dir=>".",
                :exename=>"julia",
                :extrainputs=>["/path/to/file1.gz"],
                :extrajdl=>["RequestCpus = 1"],
                :extraenv=>["tar xf file1.gz", "setup_command()"],
               )
addprocs(HTCManager(8); myparams...)
```
and `addprocs(HTCManager(8))` behaves as before.

To address the second, I made the master instance of julia bind to `0.0.0.0`, as suggested in https://github.com/JuliaParallel/ClusterManagers.jl/issues/107 (and explained in https://github.com/JuliaParallel/MPI.jl/pull/222). I have the impression that most HTCondor worker processes are not on the submission/login node, so I guess the new binding address should be the default, though I defer to others on this.