### PR TITLE
Missing kwargs in qsub addproc

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ julia>  From worker 2:  compute-6
 
 Some clusters require the user to specify a list of required resources. 
 For example, it may be necessary to specify how much memory will be needed by the job - see this [issue](https://github.com/JuliaLang/julia/issues/10390).
-The keyword `queue` can be used to specify these and other options.
+The keyword `qsub_flags` can be used to specify these and other options.
 Additionally the keyword `wd` can be used to specify the working directory (which defaults to `ENV["HOME"]`).
 
 ```julia
 julia> using Distributed, ClusterManagers
 
-julia> addprocs_sge(5;queue=`-q queue_name -l h_vmem=4G,tmem=4G`, wd=mktempdir())
+julia> addprocs_sge(5; qsub_flags=`-q queue_name -l h_vmem=4G,tmem=4G`, wd=mktempdir())
 Job 5672349 in queue.
 Running.
 5-element Array{Int64,1}:

--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -113,8 +113,8 @@ function kill(manager::Union{PBSManager, SGEManager, QRSHManager}, id::Int64, co
     end
 end
 
-addprocs_pbs(np::Integer; qsub_flags=``, wd=ENV["HOME"]) = addprocs(PBSManager(np, qsub_flags, wd))
+addprocs_pbs(np::Integer; qsub_flags=``, wd=ENV["HOME"], kwargs...) = addprocs(PBSManager(np, qsub_flags, wd); kwargs...)
 
-addprocs_sge(np::Integer; qsub_flags=``, wd=ENV["HOME"]) = addprocs(SGEManager(np, qsub_flags, wd))
+addprocs_sge(np::Integer; qsub_flags=``, wd=ENV["HOME"], kwargs...) = addprocs(SGEManager(np, qsub_flags, wd); kwargs...)
 
-addprocs_qrsh(np::Integer; qsub_flags=``, wd=ENV["HOME"]) = addprocs(QRSHManager(np, qsub_flags, wd))
+addprocs_qrsh(np::Integer; qsub_flags=``, wd=ENV["HOME"], kwargs...) = addprocs(QRSHManager(np, qsub_flags, wd); kwargs...)


### PR DESCRIPTION
I've noticed that`kwargs` were missing in the addproc of qsub. 

This is useful for example to run jobs with `exeflags="--project"` like in #144 