### PR TITLE
Add reference to K8sClusterManager in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Support for different job queue systems commonly used on compute clusters.
 | HTCondor | `addprocs_htc(np::Integer)` or `addprocs(HTCManager(np))` |
 | Slurm | `addprocs_slurm(np::Integer; kwargs...)` or `addprocs(SlurmManager(np); kwargs...)` |
 | Local manager with CPU affinity setting | `addprocs(LocalAffinityManager(;np=CPU_CORES, mode::AffinityMode=BALANCED, affinities=[]); kwargs...)` |
+| Kubernetes (K8s) via [K8sClusterManagers.jl](https://github.com/beacon-biosignals/K8sClusterManagers.jl) | `addprocs(K8sClusterManagers(np; kwargs...))` |
 
 You can also write your own custom cluster manager; see the instructions in the [Julia manual](https://docs.julialang.org/en/v1/manual/distributed-computing/#ClusterManagers)
 


### PR DESCRIPTION
As ClusterManagers.jl seems to be the [first place people look for additional cluster managers](https://julialang.slack.com/archives/C674VR0HH/p1626551368170300?thread_ts=1626540412.168100&cid=C674VR0HH) it may be good to include references to external cluster managers as part of the table in the README. 

Other managers that possible should be added could be:
- https://github.com/JuliaParallel/Elly.jl
- https://github.com/JuliaCloud/AWSClusterManagers.jl

There may be a better approach to improving discoverability of Julia cluster managers. This just seemed like an easy approach. 