### PR TITLE
Bump version with slurm retry_delays fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClusterManagers"
 uuid = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
This PR bumps to v0.4.3.

The current version v0.4.2 predates the latest change by @David96 which would be useful for running on slurm. 