### PR TITLE
Close and reopen stream after bpeek exits

### DIFF
--- a/src/lsf.jl
+++ b/src/lsf.jl
@@ -40,8 +40,11 @@ function lsf_bpeek(manager::LSFManager, jobid, iarray)
     worker_started, bytestr, host, port = parse_host_port(stream)
     worker_started && return stream, host, port
 
-    for retry_delay in retry_delays   
-        if occursin("Not yet started", bytestr)
+    for retry_delay in retry_delays 
+        # isempty is for the case when -f flag is not used to handle the case when 
+        # the << output from ... >> message is printed but the julia worker has not
+        # yet printed the ip and port nr
+        if isempty(bytestr) || occursin("Not yet started", bytestr)
             # bpeek process would have stopped
             # stream starts spewing out empty strings after this (in julia != 1.6) 
             # instead of trying to handle that we just close it and open a new stream


### PR DESCRIPTION
Fixes #182 

Not sure is this is the right way to go about it. Rather than trying to handle a flood of empty strings we just close the stream and open a new one when we think that bpeek has terminated (i.e when bpeek outputs "Not yet started" ).

Not sure what will/should happen when stream is passed over to Distributed if user does not pass -f. Does it know what to do with empty strings or should we close the stream if the process has exited?