### PR TITLE
improvement and bug fix for condor

### DIFF
--- a/src/ClusterManagers.jl
+++ b/src/ClusterManagers.jl
@@ -7,7 +7,8 @@ using Pkg
 export launch, manage, kill, init_worker, connect
 import Distributed: launch, manage, kill, init_worker, connect
 
-worker_arg() = `--worker=$(Distributed.init_multi(); cluster_cookie())`
+worker_cookie() = begin Distributed.init_multi(); cluster_cookie() end
+worker_arg() = `--worker=$(worker_cookie())`
 
 
 # PBS doesn't have the same semantics as SGE wrt to file accumulate,

--- a/src/condor.jl
+++ b/src/condor.jl
@@ -26,11 +26,13 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
         println(scriptf, line)
     end
     println(scriptf, "cd $(Base.shell_escape(dir))")
-    println(scriptf, "$(Base.shell_escape(exename)) $exeflags $(Base.shell_escape(worker_arg())) | $telnetexe $(Base.shell_escape(hostname)) $portnum")
+    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(exeflags)) \
+            -e 'using Distributed; start_worker($(repr(worker_cookie())))' \
+            | $telnetexe $(Base.shell_escape(hostname)) $portnum")
     close(scriptf)
 
     input_files = ["$tdir/$jobname.sh"]
-    push!(input_files, extrainputs...)
+    append!(input_files, extrainputs)
     subf = open("$tdir/$jobname.sub", "w")
     println(subf, "executable = /bin/bash")
     println(subf, "arguments = ./$jobname.sh")
@@ -54,7 +56,7 @@ end
 function launch(manager::HTCManager, params::Dict, instances_arr::Array, c::Condition)
     try
         portnum = rand(8000:9000)
-        _, server = listenany(Sockets.getaddrinfo("0.0.0.0"), portnum)
+        portnum, server = listenany(ip"0.0.0.0", portnum)
         np = manager.np
 
         script = condor_script(portnum, np, params)
@@ -85,7 +87,7 @@ end
 
 function manage(manager::HTCManager, id::Integer, config::WorkerConfig, op::Symbol)
     if op == :finalize
-        if !isnull(config.io)
+        if !isnothing(config.io)
             close(get(config.io))
         end
 #     elseif op == :interrupt

--- a/src/condor.jl
+++ b/src/condor.jl
@@ -83,10 +83,15 @@ function launch(manager::HTCManager, params::Dict, instances_arr::Array, c::Cond
    end
 end
 
+function kill(manager::HTCManager, id::Int64, config::WorkerConfig)
+    remotecall(exit,id)
+    close(config.io)
+end
+
 function manage(manager::HTCManager, id::Integer, config::WorkerConfig, op::Symbol)
     if op == :finalize
         if !isnothing(config.io)
-            close(get(config.io))
+            close(config.io)
         end
 #     elseif op == :interrupt
 #         job = config[:job]

--- a/src/condor.jl
+++ b/src/condor.jl
@@ -26,9 +26,7 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
         println(scriptf, line)
     end
     println(scriptf, "cd $(Base.shell_escape(dir))")
-    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(exeflags)) \
-            -e 'using Distributed; start_worker($(repr(worker_cookie())))' \
-            | $telnetexe $(Base.shell_escape(hostname)) $portnum")
+    println(scriptf, "$(Base.shell_escape(exename)) $(Base.shell_escape(exeflags)) -e 'using Distributed; start_worker($(repr(worker_cookie())))' | $telnetexe $(Base.shell_escape(hostname)) $portnum")
     close(scriptf)
 
     input_files = ["$tdir/$jobname.sh"]


### PR DESCRIPTION
Bug fix:
- `listenany` doesn't guarantee the port number, so we should use the `portnum` returned
- finalizer is bugged, `isnull` doesn't exist

Improvement:
- instead of doing `--worker = <cookie>`, we manually call `start_worker(<cookie>)` such that user can use `-e "..."` to pre-execute stuff. In my case, I want to patch `Sockets.getipaddr()` such that it skips internal private IP range.


This is possible because Julia stacks multiple `-e` command line options

This PR doesn't have impact on any other backend and is backward compatible for Condor