### PR TITLE
Update ElasticManager constructor auto IP config

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-julia = "1"
+julia = "1.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ ElasticManager(addr, port) = ElasticManager(;addr=addr, port=port)
 ElasticManager(addr, port, cookie) = ElasticManager(;addr=addr, port=port, cookie=cookie)
 ```
 
-On Linux and Mac, you can set `addr=:auto` to automatically use the host's private IP address on the local network, which will allow other workers on this network to connect. You can also use `port=0` to let the OS choose a random free port for you (some systems may not support this). Once created, printing the `ElasticManager` object prints the command which you can run on workers to connect them to the master, e.g.:
+You can set `addr=:auto` to automatically use the host's private IP address on the local network, which will allow other workers on this network to connect. You can also use `port=0` to let the OS choose a random free port for you (some systems may not support this). Once created, printing the `ElasticManager` object prints the command which you can run on workers to connect them to the master, e.g.:
 
 ```julia
 julia> em = ElasticManager(addr=:auto, port=0)


### PR DESCRIPTION
Ref discussion at #189

This PR updates the `ElasticManager` constructor to enable support for automatic IP address detection on Windows (and potentially other platforms that aren't macOS or Linux). Prior to this change, a custom `get_private_ip()` function is used to detect the platform and execute system `cmd`s to look for the machine's IP address. These changes obsolete that function in favor of a call to `Sockets.getipaddr()`, a utility that was not available until the v1.2 release of Julia.

It's possible for `Sockets.getipaddr()` to throw an error if no network interfaces are detected, so I've implemented a `try-catch` to generate a helpful error message, suggesting the IP address be specified manually. This message is largely derived from the prior `get_private_ip()` error message.

I tested this modified branch on an up-to-date Windows 11 machine and verified that it correctly resolved the local IP address with `addr=:auto`, where the prior version would simply throw an error that the feature is only supported on Mac/Linux. I've also tested it on an up-to-date Mac Mini M1 and it also correctly identified the local IP address and seems to work fine.

**Pros:**
- Enables support for `ElasticManager`s automatic IP address option in Windows and possibly other platforms that Julia supports.
- Reduces the potential for bugs/errors that could be caused by running `cmd`s and parsing the returns.

**Cons:**
- Requires the `compat` minimum for ClusterManagers.jl to be bumped from `1` to at least `1.2`.