### PR TITLE
Highlight lack of ongoing support on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Experiment to support different job queue systems commonly used on compute clusters with Distributed.jl.
 
-## Currently job queue systems
+## Available job queue systems
 
 The below table summarizes the job queue systems with implementations.
 However, several of them are known to not work with recent cluster management versions,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # ClusterManagers
 
-Support for different job queue systems commonly used on compute clusters.
+> [!WARNING]
+> This package is looking for a maintainer. Most users doing serious distributed calculations
+> should use [MPI.jl](https://github.com/JuliaParallel/MPI.jl) instead.
 
-## Currently supported job queue systems
+Experiment to support different job queue systems commonly used on compute clusters with Distributed.jl.
+
+## Currently job queue systems
+
+The below table summarizes the job queue systems with implementations.
+However, several of them are known to not work with recent cluster management versions,
+so use them with caution.
+
 
 | Job queue system | Command to add processors |
 | ---------------- | ------------------------- |


### PR DESCRIPTION
Since many of the cluster managers do not actually work (#196 #189 #185 #179 #163 ...), I think it is very important to state this up-front on the README. Currently the README explicitly states that all of these cluster managers are "currently supported" which causes users like myself to spend an enormous amount of time trying to get it working, only to find out it is not actually maintained/tested.

I sincerely empathize that it is very hard to find an active maintainer for all of these cluster managers. So I think it is just much better to be up front about this lack of ongoing support so that users don't get stuck.