### PR TITLE
Make SLUM worker startup more robust and provide more feedback

### DIFF
--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -72,7 +72,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         slurm_spec_regex = r"([\w]+):([\d]+)#(\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})"
         retry_delays = manager.retry_delays
         for i = 0:np - 1
-            println("connecting to worker $(i + 1) out of $np")
+            @info "connecting to worker $(i + 1) out of $np"
             slurm_spec_match = nothing
             if has_output_name
                 fn = job_output_template
@@ -115,7 +115,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
             notify(c)
         end
     catch e
-        println("Error launching Slurm job:")
+        @error "Error launching Slurm job"
         rethrow(e)
     end
 end

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -63,7 +63,7 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
 	    job_output_name = "$(jobname)-$(trunc(Int, Base.time() * 10))"
 	    make_job_output_path(task_num) = joinpath(job_file_loc, "$(job_output_name)-$(task_num).out")
 	    job_output_template = make_job_output_path("%4t")
-	    append!(srunargs, "-o", job_output_template)
+	    push!(srunargs, "-o", job_output_template)
 	end
 
         np = manager.np

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -51,20 +51,20 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
             mkdir(job_file_loc)
         end
 
-	# Check for given output file name
-	jobname = "julia-$(getpid())"
-	has_output_name = ("-o" in srunargs) | ("--output" in srunargs)
-	if has_output_name
-	    loc = findfirst(x-> x == "-o" || x == "--output", srunargs)
-	    job_output_name = srunargs[loc+1]
-	    job_output_template = joinpath(job_file_loc, job_output_name)
-	    srunargs[loc+1] = job_output_template
-	else
-	    job_output_name = "$(jobname)-$(trunc(Int, Base.time() * 10))"
-	    make_job_output_path(task_num) = joinpath(job_file_loc, "$(job_output_name)-$(task_num).out")
-	    job_output_template = make_job_output_path("%4t")
-	    push!(srunargs, "-o", job_output_template)
-	end
+        # Check for given output file name
+        jobname = "julia-$(getpid())"
+        has_output_name = ("-o" in srunargs) | ("--output" in srunargs)
+        if has_output_name
+            loc = findfirst(x-> x == "-o" || x == "--output", srunargs)
+            job_output_name = srunargs[loc+1]
+            job_output_template = joinpath(job_file_loc, job_output_name)
+            srunargs[loc+1] = job_output_template
+        else
+            job_output_name = "$(jobname)-$(trunc(Int, Base.time() * 10))"
+            make_job_output_path(task_num) = joinpath(job_file_loc, "$(job_output_name)-$(task_num).out")
+            job_output_template = make_job_output_path("%4t")
+            push!(srunargs, "-o", job_output_template)
+        end
 
         np = manager.np
         srun_cmd = `srun -J $jobname -n $np -D $exehome $(srunargs) $exename $exeflags $(worker_arg())`
@@ -74,11 +74,11 @@ function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
         for i = 0:np - 1
             println("connecting to worker $(i + 1) out of $np")
             slurm_spec_match = nothing
-	    if has_output_name
-		fn = job_output_template
-	    else
-		fn = make_job_output_path(lpad(i, 4, "0"))
-	    end
+            if has_output_name
+                fn = job_output_template
+            else
+                fn = make_job_output_path(lpad(i, 4, "0"))
+            end
             t0 = time()
             for retry_delay in retry_delays
                 # Wait for output log to be created and populated, then parse


### PR DESCRIPTION
Builds on top of #199.

Before (but with fix in #199):

```
# ... wait (but what's going on?) ...

connecting to worker 1 out of 12
connecting to worker 2 out of 12
connecting to worker 3 out of 12
connecting to worker 4 out of 12
connecting to worker 5 out of 12
connecting to worker 6 out of 12
connecting to worker 7 out of 12
connecting to worker 8 out of 12
connecting to worker 9 out of 12
connecting to worker 10 out of 12
connecting to worker 11 out of 12
connecting to worker 12 out of 12
```

After:

```
[ Info: Starting SLURM job julia-26323452: `srun -J julia-26323452 -n 12 -D /homedir/some/dir --cpus-per-task=8 --mem-per-cpu=8G --cpu-bind=cores --mem-bind=local -o /homedir/slurm-julia-output/julia-26323452-12983479872-%4t.out /path/to/bin/julia --project=/homedir/.julia/environments/someenv --threads=8 --heap-size-hint=34359738368 --worker=qy8ZReqHiDfwjq6a`
[ Info: Worker 0 (after 0 s): No output file "/homedir/slurm-julia-output/julia-26323452-12983479872-0000.out" yet
[ Info: Worker 0 (after 1 s): Output file found, but no connection details yet
[ Info: Worker 0 (after 2 s): Output file found, but no connection details yet
[ Info: Worker 0 (after 4 s): Output file found, but no connection details yet
[ Info: Worker 0 (after 6 s): Output file found, but no connection details yet
[ Info: Worker 0 ready after 10 s on host 149.217.13.126, port 9101
[ Info: Worker 1 ready after 10 s on host 149.217.13.126, port 9102
[ Info: Worker 2 ready after 10 s on host 149.217.13.126, port 9103
[ Info: Worker 3 ready after 11 s on host 149.217.13.126, port 9104
[ Info: Worker 4 ready after 11 s on host 149.217.13.126, port 9105
[ Info: Worker 5 ready after 11 s on host 149.217.13.126, port 9106
[ Info: Worker 6 ready after 12 s on host 149.217.13.126, port 9107
[ Info: Worker 7 ready after 12 s on host 149.217.13.126, port 9108
[ Info: Worker 8 ready after 12 s on host 149.217.13.126, port 9109
[ Info: Worker 9 ready after 12 s on host 149.217.13.126, port 9110
[ Info: Worker 10 ready after 12 s on host 149.217.13.126, port 9111
[ Info: Worker 11 ready after 12 s on host 149.217.13.126, port 9112
```