### PR TITLE
README: Mention that the package is not actively maintained or tested, and add a call for maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 The `ClusterManager.jl` package implements code for different job queue systems commonly used on compute clusters.
 
+> [!WARNING]
+> This package is not currently being actively maintained or tested.
+>
+> We are in the process of splitting this package up into multiple smaller packages, with a separate package for each job queue systems
+>
+> We are seeking maintainers for these new packages. If you are an active user of any of the job queue systems listed below and are interested in being a maintainer, please open a GitHub issue - say that you are interested in being a maintainer, and specify which job queue system you use.
+
 ## Available job queue systems
 
 Implemented in this package (the `ClusterManagers.jl` package):


### PR DESCRIPTION
Alternative to #197.

The difference from #197 is that in this PR, we explicitly say that we have the goal of splitting up this package (#58).

#197 says "looking for a maintainer" - in this PR, we instead explicitly ask only for people to maintain a single manager. I think this is a more realistic goal. I think it's more likely that we can find e.g. three separate people to maintain three separate managers vs. finding a single person willing to maintain all of the managers that currently live in this package.