### PR TITLE
README: Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Implemented in external packages:
 
 | Job queue system | Command to add processors |
 | ---------------- | ------------------------- |
-| Kubernetes (K8s) via [K8sClusterManagers.jl](https://github.com/beacon-biosignals/K8sClusterManagers.jl) | `addprocs(K8sClusterManagers(np; kwargs...))` |
+| Kubernetes (K8s) via [K8sClusterManagers.jl](https://github.com/beacon-biosignals/K8sClusterManagers.jl) | `addprocs(K8sClusterManager(np; kwargs...))` |
 | Azure scale-sets via [AzManagers.jl](https://github.com/ChevronETC/AzManagers.jl) | `addprocs(vmtemplate, n; kwargs...)` |
 
 You can also write your own custom cluster manager; see the instructions in the [Julia manual](https://docs.julialang.org/en/v1/manual/distributed-computing/#ClusterManagers).


### PR DESCRIPTION
In the `K8sClusterManagers.jl` package, the type is called `K8sClusterManagers.K8sClusterManager` (not `K8sClusterManagers.K8sClusterManagers`).