### PR TITLE
Bump version from `0.4.8` to `0.4.9`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClusterManagers"
 uuid = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"
-version = "0.4.8"
+version = "0.4.9"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
In preparation for a new release.