### PR TITLE
Deprecate (but do not remove) the Slurm functionality in this package (and point users to SlurmClusterManager.jl instead)

### DIFF
--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -15,6 +15,15 @@ end
 
 function launch(manager::SlurmManager, params::Dict, instances_arr::Array,
                 c::Condition)
+    let
+        msg = "The Slurm functionality in the `ClusterManagers.jl` package is deprecated " *
+              "(including `ClusterManagers.addprocs_slurm` and `ClusterManagers.SlurmManager`). " *
+              "It will be removed from ClusterManagers.jl in a future release. " *
+              "We recommend migrating to the " *
+              "[https://github.com/JuliaParallel/SlurmClusterManager.jl](https://github.com/JuliaParallel/SlurmClusterManager.jl) " *
+              "package instead."
+        Base.depwarn(msg, :SlurmManager; force = true)
+    end
     try
         exehome = params[:dir]
         exename = params[:exename]


### PR DESCRIPTION
Depends on:
- [x] #245

---

We'll first release a non-breaking release of ClusterManagers.jl with the deprecation warning.

Then, we'll follow-up with a breaking release of ClusterManagers.jl that fully removes the Slurm functionality from this package.

The README (of this package) will point users to the SlurmClusterManager.jl package instead.