### PR TITLE
Add `depwarn`s (but do not remove) the managers that are not currently being maintained (SGE, PBS, HTCondor, and Scyld)

### DIFF
--- a/src/condor.jl
+++ b/src/condor.jl
@@ -52,6 +52,15 @@ function condor_script(portnum::Integer, np::Integer, params::Dict)
 end
 
 function launch(manager::HTCManager, params::Dict, instances_arr::Array, c::Condition)
+    let
+        mgr_desc = "HTCondor"
+        msg = "The $(mgr_desc) functionality in ClusterManagers.jl is currently not actively maintained. " *
+              "We are currently looking for a new maintainer. " * 
+              "If you are an active user of the $(mgr_desc) functionality and are interested in becoming the maintainer, " *
+              "Please open an issue on the JuliaParallel/ClusterManagers.jl repo: " * 
+              "https://github.com/JuliaParallel/ClusterManagers.jl/issues"
+        Base.depwarn(msg, Symbol(typeof(manager)))
+    end
     try
         portnum = rand(8000:9000)
         portnum, server = listenany(ip"0.0.0.0", portnum)

--- a/src/qsub.jl
+++ b/src/qsub.jl
@@ -20,6 +20,25 @@ end
 
 function launch(manager::Union{PBSManager, SGEManager, QRSHManager},
         params::Dict, instances_arr::Array, c::Condition)
+    let
+        if manager isa PBSManager
+            mgr_desc = "Portable Batch System (PBS)"
+        elseif manager isa SGEManager
+            mgr_desc = "Sun Grid Engine (SGE)"
+        else
+            # manager isa QRSHManager
+            #
+            # `qrsh` is only available for SGE.
+            # It is not available for OpenPBS.
+            mgr_desc = "Sun Grid Engine (SGE)"
+        end
+        msg = "The $(mgr_desc) functionality in ClusterManagers.jl is currently not actively maintained. " *
+              "We are currently looking for a new maintainer. " * 
+              "If you are an active user of the $(mgr_desc) functionality and are interested in becoming the maintainer, " *
+              "Please open an issue on the JuliaParallel/ClusterManagers.jl repo: " * 
+              "https://github.com/JuliaParallel/ClusterManagers.jl/issues"
+        Base.depwarn(msg, Symbol(typeof(manager)))
+    end
     try
         dir = params[:dir]
         exename = params[:exename]

--- a/src/scyld.jl
+++ b/src/scyld.jl
@@ -5,6 +5,15 @@ struct ScyldManager <: ClusterManager
 end
 
 function launch(manager::ScyldManager, params::Dict, instances_arr::Array, c::Condition)
+    let
+        manager_description = "Scyld ClusterWare"
+        msg = "The $(mgr_desc) functionality in ClusterManagers.jl is currently not actively maintained. " *
+              "We are currently looking for a new maintainer. " * 
+              "If you are an active user of the $(mgr_desc) functionality and are interested in becoming the maintainer, " *
+              "Please open an issue on the JuliaParallel/ClusterManagers.jl repo: " * 
+              "https://github.com/JuliaParallel/ClusterManagers.jl/issues"
+        Base.depwarn(msg, Symbol(typeof(manager)))
+    end
     try
         dir = params[:dir]
         exename = params[:exename]


### PR DESCRIPTION
These managers do not currently have a maintainer. So let's add `depwarn`s. If we are able to recruit a maintainer in the future, we can remove the `depwarn` at that time.

1. SGE (via `qsub` or `qrsh`).
2. PBS (via `qsub`).
3. HTCondor (via `condor_submit`).
4. Scyld ClusterWare (via `bpsh`).