### PR TITLE
README: Move the unmaintained managers (SGE, PBS, HTCondor, and Scyld) to a separate table

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following managers are implemented in this package (the `ClusterManagers.jl`
 | ---------------- | ------------------------- |
 | Local manager with CPU affinity setting | `addprocs(LocalAffinityManager(;np=CPU_CORES, mode::AffinityMode=BALANCED, affinities=[]); kwargs...)` |
 
-## Implemented in external packages
+### Implemented in external packages
 
 | Job queue system | External package | Command to add processors |
 | ---------------- | ---------------- | ------------------------- |
@@ -26,7 +26,7 @@ The following managers are implemented in this package (the `ClusterManagers.jl`
 | Kubernetes (K8s) | [K8sClusterManagers.jl](https://github.com/beacon-biosignals/K8sClusterManagers.jl) | `addprocs(K8sClusterManager(np; kwargs...))` |
 | Azure scale-sets | [AzManagers.jl](https://github.com/ChevronETC/AzManagers.jl) | `addprocs(vmtemplate, n; kwargs...)` |
 
-## Not currently being actively maintained
+### Not currently being actively maintained
 
 > [!WARNING]
 > The following managers are not currently being actively maintained or tested.
@@ -42,9 +42,11 @@ The following managers are implemented in this package (the `ClusterManagers.jl`
 | Scyld | `addprocs_scyld(np::Integer)` or `addprocs(ScyldManager(np))` |
 | HTCondor | `addprocs_htc(np::Integer)` or `addprocs(HTCManager(np))` |
 
-## Custom managers
+### Custom managers
 
 You can also write your own custom cluster manager; see the instructions in the [Julia manual](https://docs.julialang.org/en/v1/manual/distributed-computing/#ClusterManagers).
+
+## Notes on specific managers
 
 ### Slurm: please see [SlurmClusterManager.jl](https://github.com/JuliaParallel/SlurmClusterManager.jl)
 

--- a/README.md
+++ b/README.md
@@ -2,29 +2,15 @@
 
 The `ClusterManagers.jl` package implements code for different job queue systems commonly used on compute clusters.
 
-> [!WARNING]
-> This package is not currently being actively maintained or tested.
->
-> We are in the process of splitting this package up into multiple smaller packages, with a separate package for each job queue systems.
->
-> We are seeking maintainers for these new packages. If you are an active user of any of the job queue systems listed below and are interested in being a maintainer, please open a GitHub issue - say that you are interested in being a maintainer, and specify which job queue system you use.
-
 ## Available job queue systems
 
-Implemented in this package (the `ClusterManagers.jl` package):
+The following managers are implemented in this package (the `ClusterManagers.jl` package):
 
 | Job queue system | Command to add processors |
 | ---------------- | ------------------------- |
-| Sun Grid Engine (SGE) via `qsub` | `addprocs_sge(np::Integer; qsub_flags=``)` or `addprocs(SGEManager(np, qsub_flags))` |
-| Sun Grid Engine (SGE) via `qrsh` | `addprocs_qrsh(np::Integer; qsub_flags=``)` or `addprocs(QRSHManager(np, qsub_flags))` |
-| PBS (Portable Batch System) | `addprocs_pbs(np::Integer; qsub_flags=``)` or `addprocs(PBSManager(np, qsub_flags))` |
-| Scyld | `addprocs_scyld(np::Integer)` or `addprocs(ScyldManager(np))` |
-| HTCondor[^1] | `addprocs_htc(np::Integer)` or `addprocs(HTCManager(np))` |
 | Local manager with CPU affinity setting | `addprocs(LocalAffinityManager(;np=CPU_CORES, mode::AffinityMode=BALANCED, affinities=[]); kwargs...)` |
 
-[^1]: HTCondor was previously named Condor.
-
-Implemented in external packages:
+## Implemented in external packages
 
 | Job queue system | External package | Command to add processors |
 | ---------------- | ---------------- | ------------------------- |
@@ -32,6 +18,24 @@ Implemented in external packages:
 | Load Sharing Facility (LSF) | [LSFClusterManager.jl](https://github.com/JuliaParallel/LSFClusterManager.jl) | `addprocs_lsf(np::Integer; bsub_flags=``, ssh_cmd=``)` or `addprocs(LSFManager(np, bsub_flags, ssh_cmd, retry_delays, throttle))` |
 | Kubernetes (K8s) | [K8sClusterManagers.jl](https://github.com/beacon-biosignals/K8sClusterManagers.jl) | `addprocs(K8sClusterManager(np; kwargs...))` |
 | Azure scale-sets | [AzManagers.jl](https://github.com/ChevronETC/AzManagers.jl) | `addprocs(vmtemplate, n; kwargs...)` |
+
+## Not currently being actively maintained
+
+> [!WARNING]
+> The following managers are not currently being actively maintained or tested.
+>
+> We are seeking maintainers for the following managers. If you are an active user of any of the following job queue systems listed and are interested in being a maintainer, please open a GitHub issue - say that you are interested in being a maintainer, and specify which job queue system you use.
+>
+
+| Job queue system | Command to add processors |
+| ---------------- | ------------------------- |
+| Sun Grid Engine (SGE) via `qsub` | `addprocs_sge(np::Integer; qsub_flags=``)` or `addprocs(SGEManager(np, qsub_flags))` |
+| Sun Grid Engine (SGE) via `qrsh` | `addprocs_qrsh(np::Integer; qsub_flags=``)` or `addprocs(QRSHManager(np, qsub_flags))` |
+| PBS (Portable Batch System) | `addprocs_pbs(np::Integer; qsub_flags=``)` or `addprocs(PBSManager(np, qsub_flags))` |
+| Scyld | `addprocs_scyld(np::Integer)` or `addprocs(ScyldManager(np))` |
+| HTCondor | `addprocs_htc(np::Integer)` or `addprocs(HTCManager(np))` |
+
+## Custom managers
 
 You can also write your own custom cluster manager; see the instructions in the [Julia manual](https://docs.julialang.org/en/v1/manual/distributed-computing/#ClusterManagers).
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 The `ClusterManagers.jl` package implements code for different job queue systems commonly used on compute clusters.
 
+> [!WARNING]
+> This package is not currently being actively maintained or tested.
+>
+> We are in the process of splitting this package up into multiple smaller packages, with a separate package for each job queue systems.
+>
+> We are seeking maintainers for these new packages. If you are an active user of any of the job queue systems listed below and are interested in being a maintainer, please open a GitHub issue - say that you are interested in being a maintainer, and specify which job queue system you use.
+
 ## Available job queue systems
 
 The following managers are implemented in this package (the `ClusterManagers.jl` package):

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The `ClusterManagers.jl` package implements code for different job queue systems
 
 ## Available job queue systems
 
+### In this package
+
 The following managers are implemented in this package (the `ClusterManagers.jl` package):
 
 | Job queue system | Command to add processors |


### PR DESCRIPTION
Follow-up to #247 and #248.